### PR TITLE
Use alpha for cursor line

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -22,6 +22,7 @@ bg2 = ''
 bg3 = ''
 fg1 = ''
 fg2 = ''
+cl = ''
 
 
 module.exports =
@@ -90,6 +91,7 @@ setColors = ->
   fg1 = chroma.mix( bg1, uno1, .3)    # how much uno
   fg2 = chroma.mix( bg1, uno1, .1)    # how much uno
 
+  cl  = chroma(uno1).alpha(0.04).css() # cursor line needs to have alpha
 
   # Remove all properties
   # Prevents adding endless properties
@@ -111,6 +113,8 @@ setColors = ->
 
   root.style.setProperty('--fg-1', fg1)
   root.style.setProperty('--fg-2', fg2)
+
+  root.style.setProperty('--cl', cl)
 
   root.style.setProperty('--accent', tri1)
 
@@ -135,6 +139,8 @@ unsetColors = ->
 
   root.style.removeProperty('--fg-1')
   root.style.removeProperty('--fg-2')
+
+  root.style.removeProperty('--cl')
 
   root.style.removeProperty('--accent')
 

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -6,7 +6,7 @@ atom-text-editor {
   .bg-1(); // @syntax-background-color
 
   .line.cursor-line {
-    .bg-2();
+    .cl();
   }
 
   .selection .region {

--- a/styles/palette.less
+++ b/styles/palette.less
@@ -16,3 +16,5 @@
 
 .fg-1 { color: var(--fg-1); } // ..  Strong
 .fg-2 { color: var(--fg-2); } // ..  Weak
+
+.cl { background-color: var(--cl); } // uno-1 + alpha


### PR DESCRIPTION
This makes the cursor line background have alpha transparency. So that highlights (bracket-matcher, search results) are visible underneath.

![cl](https://user-images.githubusercontent.com/378023/34244988-4edb3074-e66b-11e7-8d43-f486241288b4.gif)

Fixes #4